### PR TITLE
checkError: Add more information when failing

### DIFF
--- a/test/lsm_test.go
+++ b/test/lsm_test.go
@@ -1222,9 +1222,17 @@ func TestHealthStatus(t *testing.T) {
 
 func checkError(t *testing.T, err error) {
 	var e = err.(*errors.LsmError)
+
 	if os.Getuid() == 0 {
+		if errors.NoSupport != e.Code {
+			fmt.Printf("checkError e: %v\n", e)
+		}
 		assert.Equal(t, errors.NoSupport, e.Code)
 	} else {
+		if e.Code != errors.PermissionDenied && e.Code != errors.NoSupport {
+			fmt.Printf("checkError e: %v\n", e)
+		}
+
 		assert.True(t, e.Code == errors.PermissionDenied || e.Code == errors.NoSupport)
 	}
 }


### PR DESCRIPTION
When we actually fail and assert in this check it's useful to
know a bit more.

Signed-off-by: Tony Asleson <tasleson@redhat.com>