### PR TITLE
Update ci fedora image to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   fedora:
     docker:
-      - image: fedora:33
+      - image: fedora
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Circle ci has updated their base OS kernel.

Signed-off-by: Tony Asleson <tasleson@redhat.com>